### PR TITLE
Modernize project metadata, docs, and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust: [stable, nightly]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+      - run: cargo test --verbose
+      - run: cargo test --verbose --no-default-features --features hasher-fnv
+
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - run: cargo clippy -- -D warnings
+
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --check

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,0 @@
-language: rust

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,18 @@
 [package]
+name = "simhash"
+version = "0.3.0"
+edition = "2021"
 authors = [
   "Bart Olsthoorn <bartolsthoorn@gmail.com>",
   "Jakub Pastuszek <jpastuszek@gmail.com>",
 ]
 license = "MIT"
-name = "simhash"
-version = "0.3.0"
-edition = "2018"
+description = "Simhash algorithm for 64-bit locality-sensitive hashing and similarity calculation"
+repository = "https://github.com/bartolsthoorn/simhash-rs"
+homepage = "https://github.com/bartolsthoorn/simhash-rs"
+keywords = ["simhash", "hash", "similarity", "hamming", "lsh"]
+categories = ["algorithms", "text-processing"]
+readme = "README.md"
 
 [features]
 default = ["hasher-sip"]

--- a/README.md
+++ b/README.md
@@ -1,18 +1,35 @@
 # Simhash for Rust
-[![Build Status](https://travis-ci.org/bartolsthoorn/simhash-rs.svg?branch=master)](https://travis-ci.org/bartolsthoorn/simhash-rs)
+[![CI](https://github.com/bartolsthoorn/simhash-rs/actions/workflows/ci.yml/badge.svg)](https://github.com/bartolsthoorn/simhash-rs/actions/workflows/ci.yml)
+[![crates.io](https://img.shields.io/crates/v/simhash.svg)](https://crates.io/crates/simhash)
 
-Simhash algorithm (developed by [Moses Charikar](http://www.cs.princeton.edu/courses/archive/spring04/cos598B/bib/CharikarEstim.pdf)) implemented in Rust. It generates 64 bit simhashes and can calculate similarities using the [Hamming distance](http://en.wikipedia.org/wiki/Hamming_distance).
+Simhash algorithm (developed by [Moses Charikar](http://www.cs.princeton.edu/courses/archive/spring04/cos598B/bib/CharikarEstim.pdf)) implemented in Rust. It generates 64-bit simhashes and can calculate similarities using the [Hamming distance](http://en.wikipedia.org/wiki/Hamming_distance).
 
-To use simhash append the following lines to your `Cargo.toml` file.
+## Usage
+
+Add `simhash` to your `Cargo.toml`:
 ```toml
 [dependencies]
-simhash = "0.3.0"
+simhash = "0.3"
 ```
 
-You can now use it in your project.
 ```rust
 fn main() {
-  let h: u64 = simhash::hash("The cat sat on the mat");
-  println!("{}", h);
+    let hash = simhash::simhash("The cat sat on the mat");
+    println!("{hash}");
+
+    let similarity = simhash::similarity("The cat sat on the mat", "The cat sat under the mat");
+    println!("{similarity}");
 }
 ```
+
+## Features
+
+By default, simhash uses [SipHash](https://crates.io/crates/siphasher) as its internal hasher. You can switch to [FNV](https://crates.io/crates/fnv) instead:
+```toml
+[dependencies]
+simhash = { version = "0.3", default-features = false, features = ["hasher-fnv"] }
+```
+
+## License
+
+MIT

--- a/benches/simhash.rs
+++ b/benches/simhash.rs
@@ -2,11 +2,10 @@
 extern crate bencher;
 extern crate simhash;
 
-use bencher::{Bencher, black_box};
+use bencher::{black_box, Bencher};
 use simhash::simhash;
 
-static ALICE: &'static str =
-r#"ALICE'S ADVENTURES IN WONDERLAND
+static ALICE: &'static str = r#"ALICE'S ADVENTURES IN WONDERLAND
 CHAPTER I. Down the Rabbit-Hole
 
 Alice was beginning to get very tired of sitting by her sister on the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,19 +34,19 @@ where
     for feature in words {
         let feature_hash: u64 = hash_feature(&feature);
 
-        for i in 0..64 {
+        for (i, weight) in v.iter_mut().enumerate() {
             let bit = (feature_hash >> i) & 1;
             if bit == 1 {
-                v[i] = v[i].saturating_add(1);
+                *weight = weight.saturating_add(1);
             } else {
-                v[i] = v[i].saturating_sub(1);
+                *weight = weight.saturating_sub(1);
             }
         }
     }
 
-    for q in 0..64 {
-        if v[q] > 0 {
-            simhash |= 1 << q;
+    for (i, weight) in v.iter().enumerate() {
+        if *weight > 0 {
+            simhash |= 1 << i;
         }
     }
     simhash


### PR DESCRIPTION
## Summary

- **CI**: Replace defunct Travis CI with GitHub Actions — tests on stable + nightly, runs clippy and rustfmt checks, exercises both `hasher-sip` and `hasher-fnv` features
- **README**: Fix deprecated `simhash::hash()` example to use `simhash::simhash()`, add crates.io version badge, document the FNV feature flag
- **Cargo.toml**: Add `description`, `repository`, `homepage`, `keywords`, `categories`, and `readme` for crates.io discoverability
- **Edition**: Bump from 2018 to 2021

## Test plan

- [x] `cargo test` passes locally (all 4 tests)
- [ ] GitHub Actions CI passes on push
- [ ] Verify `cargo publish --dry-run` succeeds before publishing 0.3.0


Made with [Cursor](https://cursor.com)